### PR TITLE
Support for Gentoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ paru -S yafetch
 
 >NOTE: `yaf` was taken so had to publish with `yafetch` name.
 
-### Gentoo
+### Gentoo Linux
 
 Create the `/etc/portage/repos.conf/yaf.conf` file as follows:
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ then run `emaint -r yaf sync`
 
 now you can run `root# emerge --ask app-misc/yaf-bin` or `root# emerge --ask app-misc/yaf`
 
+If there are any issue please make an issue at <a href="https://github.com/ThamognyaKodi/yaf-gentoo-ebuilds" target="_blank">yaf-gentoo-ebuilds</a>
 
 ### Manual
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Create the `/etc/portage/repos.conf/yaf.conf` file as follows:
 priority = 50
 location = <repo-location>/yaf
 sync-type = git
-sync-uri = //add link here
+sync-uri = git@github.com:ThamognyaKodi/yaf-gentoo-ebuilds.git
 auto-sync = Yes
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Create the `/etc/portage/repos.conf/yaf.conf` file as follows:
 priority = 50
 location = <repo-location>/yaf
 sync-type = git
-sync-uri = git@github.com:ThamognyaKodi/yaf-gentoo-ebuilds.git
+sync-uri = https://github.com/ThamognyaKodi/yaf-gentoo-ebuilds.git
 auto-sync = Yes
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ paru -S yafetch
 Create the `/etc/portage/repos.conf/yaf.conf` file as follows:
 
 ```
-[librewolf]
+[yaf]
 priority = 50
 location = <repo-location>/yaf
 sync-type = git

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Yet Another Fetch is a tool that fetches system information and shows it in a be
 
 - [Binary](#binary)
 - [Arch Linux](#arch-linux)
+- [Gentoo Linux](#gentoo-linux)
 - [Manual](#manual)
 
 ### Binary
@@ -47,6 +48,26 @@ paru -S yafetch
 ```
 
 >NOTE: `yaf` was taken so had to publish with `yafetch` name.
+
+### Gentoo
+
+Create the `/etc/portage/repos.conf/yaf.conf` file as follows:
+
+```
+[librewolf]
+priority = 50
+location = <repo-location>/yaf
+sync-type = git
+sync-uri = //add link here
+auto-sync = Yes
+```
+
+Change the `<repo-location>` to anything preferably `/var/db/repos/`
+
+then run `emaint -r yaf sync`
+
+now you can run `root# emerge --ask app-misc/yaf-bin` or `root# emerge --ask app-misc/yaf`
+
 
 ### Manual
 


### PR DESCRIPTION
These are the instructions to install yaf for Gentoo. I have put the instructions in `README.md`. The ebuilds are still under testing but it should work. I have also put a link for the users to put an issue to the ebuild.